### PR TITLE
moving warframe-items to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,12 @@
     "": {
       "name": "wf-emulator",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "GNU",
       "dependencies": {
         "dotenv": "^16.1.3",
         "express": "^5.0.0-beta.1",
         "mongoose": "^8.0.2",
-        "warframe-items": "1.1260.121",
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^4.7.1"
       },
@@ -28,7 +28,8 @@
         "prettier": "^3.0.0",
         "ts-node-dev": "^2.0.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "warframe-items": "1.1260.121"
       },
       "engines": {
         "node": ">=18.15.0",
@@ -3975,7 +3976,8 @@
     "node_modules/warframe-items": {
       "version": "1.1260.121",
       "resolved": "https://registry.npmjs.org/warframe-items/-/warframe-items-1.1260.121.tgz",
-      "integrity": "sha512-C/te9WSsc3HzeSAgziAGKs6sKnYqCO41QDov8E6RUfl3D06C7ko8mHsJ2j65zF515IatJl/xelVtp0aAnQcWiQ=="
+      "integrity": "sha512-C/te9WSsc3HzeSAgziAGKs6sKnYqCO41QDov8E6RUfl3D06C7ko8mHsJ2j65zF515IatJl/xelVtp0aAnQcWiQ==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -4,18 +4,19 @@
   "description": "WF Emulator",
   "main": "index.ts",
   "scripts": {
-    "start": "node build/index.js",
     "dev": "ts-node-dev --openssl-legacy-provider -r tsconfig-paths/register src/index.ts ",
     "build": "tsc",
+    "start": "node build/index.js",
     "lint": "eslint --ext .ts .",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "update-items": "node static/json/scripts/update-items.js",
+    "postinstall": "npm run update-items"
   },
   "license": "GNU",
   "dependencies": {
     "dotenv": "^16.1.3",
     "express": "^5.0.0-beta.1",
     "mongoose": "^8.0.2",
-    "warframe-items": "1.1260.121",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1"
   },
@@ -31,7 +32,8 @@
     "prettier": "^3.0.0",
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "warframe-items": "1.1260.121"
   },
   "engines": {
     "node": ">=18.15.0",

--- a/src/helpers/customHelpers/addItemHelpers.ts
+++ b/src/helpers/customHelpers/addItemHelpers.ts
@@ -24,8 +24,7 @@ interface IAddItemRequest {
     accountId: string;
 }
 export const isInternalName = (internalName: string): boolean => {
-    const item = items.find(i => i.uniqueName === internalName);
-    return Boolean(item);
+    return items.has(internalName);
 };
 
 const parseInternalName = (internalName: unknown): string => {

--- a/src/helpers/purchaseHelpers.ts
+++ b/src/helpers/purchaseHelpers.ts
@@ -2,7 +2,7 @@ import { parseBoolean, parseNumber, parseString } from "@/src/helpers/general";
 import { WeaponTypeInternal } from "@/src/services/inventoryService";
 import { slotPurchaseNameToSlotName } from "@/src/services/purchaseService";
 import { IPurchaseRequest, SlotPurchaseName } from "@/src/types/purchaseTypes";
-import { weapons } from "@/static/data/items";
+import { weaponCategories } from "@/static/data/items";
 
 export const toPurchaseRequest = (purchaseRequest: unknown): IPurchaseRequest => {
     if (!purchaseRequest || typeof purchaseRequest !== "object") {
@@ -42,13 +42,7 @@ export const toPurchaseRequest = (purchaseRequest: unknown): IPurchaseRequest =>
 };
 
 export const getWeaponType = (weaponName: string) => {
-    const weaponInfo = weapons.find(i => i.uniqueName === weaponName);
-
-    if (!weaponInfo) {
-        throw new Error(`unknown weapon ${weaponName}`);
-    }
-
-    const weaponType = weaponInfo.productCategory as WeaponTypeInternal;
+    const weaponType = weaponCategories[weaponName] as WeaponTypeInternal;
 
     if (!weaponType) {
         throw new Error(`unknown weapon category for item ${weaponName}`);

--- a/static/data/items.ts
+++ b/static/data/items.ts
@@ -1,60 +1,19 @@
-import Items, { Category, Item, Warframe, Weapon } from "warframe-items";
+import modNamesData from "@/static/json/mod-names.json";
+import relicNamesData from "@/static/json/relic-names.json";
+import miscNamesData from "@/static/json/misc-names.json";
+import resourceNamesData from "@/static/json/resource-names.json";
+import gearNamesData from "@/static/json/gear-names.json";
+import blueprintNamesData from "@/static/json/blueprint-names.json";
+import weaponCategoriesData from "@/static/json/weapon-categories.json";
+import allUniqNames from "@/static/json/all-uniq-names.json";
 
-type MinWeapon = Omit<Weapon, "patchlogs">;
-type MinItem = Omit<Item, "patchlogs">;
+const modNames = modNamesData as ImportAssertions;
+const relicNames = relicNamesData as ImportAssertions;
+const miscNames = miscNamesData as ImportAssertions;
+const resourceNames = resourceNamesData as ImportAssertions;
+const gearNames = gearNamesData as ImportAssertions;
+const blueprintNames = blueprintNamesData as ImportAssertions;
+const weaponCategories = weaponCategoriesData as ImportAssertions;
+const items = new Set(allUniqNames);
 
-export const weapons: MinWeapon[] = (new Items({ category: ["Primary", "Secondary", "Melee"] }) as Weapon[]).map(
-    item => {
-        const next = { ...item };
-        delete next.patchlogs;
-        return next;
-    }
-);
-
-export const items: MinItem[] = new Items({ category: ["All"] }).map(item => {
-    const next = { ...item };
-    delete next.patchlogs;
-    return next;
-});
-
-const getNamesObj = (category: Category) =>
-    new Items({ category: [category] }).reduce((acc, item) => {
-        acc[item.name!.replace("'S", "'s")] = item.uniqueName!;
-        return acc;
-    }, {} as ImportAssertions);
-
-export const modNames = getNamesObj("Mods");
-export const resourceNames = getNamesObj("Resources");
-export const miscNames = getNamesObj("Misc");
-export const relicNames = getNamesObj("Relics");
-export const skinNames = getNamesObj("Skins");
-export const arcaneNames = getNamesObj("Arcanes");
-export const gearNames = getNamesObj("Gear");
-
-export const craftNames: ImportAssertions = Object.fromEntries(
-    (
-        new Items({
-            category: [
-                "Warframes",
-                "Gear",
-                "Melee",
-                "Primary",
-                "Secondary",
-                "Sentinels",
-                "Misc",
-                "Arch-Gun",
-                "Arch-Melee"
-            ]
-        }) as Warframe[]
-    )
-        .flatMap(item => item.components || [])
-        .filter(item => item.drops && item.drops[0])
-        .map(item => [item.drops![0].type, item.uniqueName])
-);
-craftNames["Forma Blueprint"] = "/Lotus/Types/Recipes/Components/FormaBlueprint";
-
-export const blueprintNames: ImportAssertions = Object.fromEntries(
-    Object.keys(craftNames)
-        .filter(name => name.includes("Blueprint"))
-        .map(name => [name, craftNames[name]])
-);
+export { modNames, relicNames, miscNames, resourceNames, gearNames, blueprintNames, weaponCategories, items };

--- a/static/json/.gitignore
+++ b/static/json/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!missions-drop-table.json
+!scripts
+!scripts/*

--- a/static/json/scripts/update-items.js
+++ b/static/json/scripts/update-items.js
@@ -1,0 +1,53 @@
+/* eslint-disable */
+const Items = require("warframe-items");
+const fs = require("fs");
+
+const weaponCategories = new Items({ category: ["Primary", "Secondary", "Melee"] }).reduce((acc, item) => {
+    acc[item.name] = item.productCategory;
+    return acc;
+}, {});
+
+const allItemTypes = new Items({ category: ["All"] }).map(item => item.uniqueName);
+
+const getNamesObj = category =>
+    new Items({ category: [category] }).reduce((acc, item) => {
+        acc[item.name.replace("'S", "'s")] = item.uniqueName;
+        return acc;
+    }, {});
+
+const modNames = getNamesObj("Mods");
+const resourceNames = getNamesObj("Resources");
+const miscNames = getNamesObj("Misc");
+const relicNames = getNamesObj("Relics");
+const skinNames = getNamesObj("Skins");
+const arcaneNames = getNamesObj("Arcanes");
+const gearNames = getNamesObj("Gear");
+
+const craftNames = Object.fromEntries(
+    new Items({
+        category: ["Warframes", "Gear", "Melee", "Primary", "Secondary", "Sentinels", "Misc", "Arch-Gun", "Arch-Melee"]
+    })
+        .flatMap(item => item.components || [])
+        .filter(item => item.drops && item.drops[0])
+        .map(item => [item.drops[0].type, item.uniqueName])
+);
+craftNames["Forma Blueprint"] = "/Lotus/Types/Recipes/Components/FormaBlueprint";
+
+const blueprintNames = Object.fromEntries(
+    Object.keys(craftNames)
+        .filter(name => name.includes("Blueprint"))
+        .map(name => [name, craftNames[name]])
+);
+
+const jsonDir = "static/json";
+
+fs.writeFileSync(`${jsonDir}/weapon-categories.json`, JSON.stringify(weaponCategories));
+fs.writeFileSync(`${jsonDir}/all-uniq-names.json`, JSON.stringify(allItemTypes));
+fs.writeFileSync(`${jsonDir}/mod-names.json`, JSON.stringify(modNames));
+fs.writeFileSync(`${jsonDir}/resource-names.json`, JSON.stringify(resourceNames));
+fs.writeFileSync(`${jsonDir}/misc-names.json`, JSON.stringify(miscNames));
+fs.writeFileSync(`${jsonDir}/relic-names.json`, JSON.stringify(relicNames));
+fs.writeFileSync(`${jsonDir}/skin-names.json`, JSON.stringify(skinNames));
+fs.writeFileSync(`${jsonDir}/arcane-names.json`, JSON.stringify(arcaneNames));
+fs.writeFileSync(`${jsonDir}/gear-names.json`, JSON.stringify(gearNames));
+fs.writeFileSync(`${jsonDir}/blueprint-names.json`, JSON.stringify(blueprintNames));


### PR DESCRIPTION
Reason: on bundled build i need whole json data folder of that package.
Now the items.ts file depends only on local files created during postinstall.