### PR TITLE
improve: skip HUB instance selection

### DIFF
--- a/src/controllers/api/hubInstancesController.ts
+++ b/src/controllers/api/hubInstancesController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from "express";
 
 const hubInstancesController: RequestHandler = (_req, res) => {
-    res.json("list 50 16 1 0 scenarios 0 0 0 0 0 0");
+    res.json("list 50 1 0 0 scenarios 0 0 0 0 0 0");
 };
 
 export { hubInstancesController };


### PR DESCRIPTION
Makes the game think there's only 1 HUB instance so it won't ask us to pick one.