### PR TITLE
feat: add spoofMasteryRank config

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -15,5 +15,6 @@
   "infiniteResources": true,
   "unlockallShipFeatures": true,
   "unlockAllShipDecorations": true,
-  "unlockAllFlavourItems": true
+  "unlockAllFlavourItems": true,
+  "spoofMasteryRank": -1
 }

--- a/src/controllers/api/inventoryController.ts
+++ b/src/controllers/api/inventoryController.ts
@@ -51,7 +51,26 @@ const inventoryController: RequestHandler = async (request: Request, response: R
     if (config.unlockAllShipDecorations) inventoryResponse.ShipDecorations = allShipDecorations;
     if (config.unlockAllFlavourItems) inventoryResponse.FlavourItems = allFlavourItems satisfies IFlavourItem[];
 
+    if (typeof config.spoofMasteryRank === "number" && config.spoofMasteryRank >= 0 && config.spoofMasteryRank <= 5030) {
+        inventoryResponse.PlayerLevel = config.spoofMasteryRank;
+        inventoryResponse.XPInfo = [];
+        let numFrames = getExpRequiredForMr(config.spoofMasteryRank) / 6000;
+        while (numFrames-- > 0) {
+            inventoryResponse.XPInfo.push({
+                ItemType: "/Lotus/Powersuits/Mag/Mag",
+                XP: 1_600_000
+            });
+        }
+    }
+
     response.json(inventoryResponse);
+};
+
+const getExpRequiredForMr = (rank: number): number => {
+    if (rank <= 30) {
+        return 2500 * rank * rank;
+    }
+    return 2_250_000 + (147_500 * (rank - 30));
 };
 
 export { inventoryController };

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -14,6 +14,7 @@ interface IConfig {
     unlockallShipFeatures?: boolean;
     unlockAllShipDecorations?: boolean;
     unlockAllFlavourItems?: boolean;
+    spoofMasteryRank?: number;
 }
 
 interface ILoggerConfig {


### PR DESCRIPTION
-1 by default to disable it. I have capped it to MR 5030 (LR 5000) to avoid this becoming too laggy. At that rank, you can spawn enemies up to level 25180 in the Simulacrum.