### PR TITLE
fix: allShipFeatures not containing ArsenalMeleeFeatureItem

### DIFF
--- a/static/fixed_responses/allShipFeatures.json
+++ b/static/fixed_responses/allShipFeatures.json
@@ -1,4 +1,5 @@
 [
+  "/Lotus/Types/Items/ShipFeatureItems/ArsenalMeleeFeatureItem",
   "/Lotus/Types/Items/ShipFeatureItems/AdvancedOrdisFeatureItem",
   "/Lotus/Types/Items/ShipFeatureItems/AlchemyRoomFeatureItem",
   "/Lotus/Types/Items/ShipFeatureItems/AlertsFeatureItem",


### PR DESCRIPTION
Needed to unlock Melee arcane & exilus slots.