### PR TITLE
fix: missing note beacon in allShipDecorations

### DIFF
--- a/static/fixed_responses/allShipDecorations.json
+++ b/static/fixed_responses/allShipDecorations.json
@@ -1,4 +1,5 @@
 [
+  { "ItemCount": 1, "ItemType": "/Lotus/Objects/Tenno/Props/TnoLisetTextProjector" },
   { "ItemCount": 1, "ItemType": "/Lotus/Types/Items/ShipDecos/7thAnniversaryPoster" },
   { "ItemCount": 1, "ItemType": "/Lotus/Types/Items/ShipDecos/8thAnniversaryPoster" },
   { "ItemCount": 1, "ItemType": "/Lotus/Types/Items/ShipDecos/AcolyteAreaCasterBobbleHead" },


### PR DESCRIPTION
This is the only orbiter decoration that does not start with `/Lotus/Types/Items/ShipDecos/`.