### PR TITLE
improve(webui): Zaw display label

### DIFF
--- a/static/webui/script.js
+++ b/static/webui/script.js
@@ -95,6 +95,7 @@ window.itemListPromise = new Promise(resolve => {
             "/Lotus/Weapons/Tenno/Pistol/LotusPistol": { name: "Pistol" },
             "/Lotus/Weapons/Tenno/Rifle/LotusRifle": { name: "Rifle" },
             "/Lotus/Weapons/Tenno/Shotgun/LotusShotgun": { name: "Shotgun" },
+            "/Lotus/Weapons/Ostron/Melee/LotusModularWeapon": {name: "Zaw"},
             // Missing in data sources
             "/Lotus/Upgrades/CosmeticEnhancers/Peculiars/CyoteMod": { name: "Traumatic Peculiar" }
         };

--- a/static/webui/script.js
+++ b/static/webui/script.js
@@ -95,6 +95,7 @@ window.itemListPromise = new Promise(resolve => {
             "/Lotus/Weapons/Tenno/Pistol/LotusPistol": { name: "Pistol" },
             "/Lotus/Weapons/Tenno/Rifle/LotusRifle": { name: "Rifle" },
             "/Lotus/Weapons/Tenno/Shotgun/LotusShotgun": { name: "Shotgun" },
+            // Modular weapons
             "/Lotus/Weapons/Ostron/Melee/LotusModularWeapon": {name: "Zaw"},
             // Missing in data sources
             "/Lotus/Upgrades/CosmeticEnhancers/Peculiars/CyoteMod": { name: "Traumatic Peculiar" }


### PR DESCRIPTION
changed modular weapon in webui from displaying "/Lotus/Weapons/Ostron/Melee/LotusModularWeapon" to "Zaw", it was too long and caused misalignment of texts and boxes
Before: 
![image](https://github.com/spaceninjaserver/SpaceNinjaServer/assets/160588255/aab0bba8-0785-4c86-b6dd-6ee135280827)
After: 
![image](https://github.com/spaceninjaserver/SpaceNinjaServer/assets/160588255/38ba1ab1-566d-4187-99c0-c9f754c8bd7a)
