### PR TITLE
NoReset Xp after Polarize

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -20,5 +20,6 @@
   "unlockAllShipDecorations": true,
   "unlockAllFlavourItems": true,
   "unlockAllSkins": true,
+  "NoResetPolarize": false,
   "spoofMasteryRank": -1
 }

--- a/src/controllers/api/upgradesController.ts
+++ b/src/controllers/api/upgradesController.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from "express";
 import { IUpgradesRequest } from "@/src/types/requestTypes";
+import { config } from "@/src/services/configService";
 import { FocusSchool, IEquipmentDatabase, EquipmentFeatures } from "@/src/types/inventoryTypes/commonInventoryTypes";
 import { IMiscItem, TEquipmentKey } from "@/src/types/inventoryTypes/inventoryTypes";
 import { getAccountIdForRequest } from "@/src/services/loginService";
@@ -64,7 +65,9 @@ export const upgradesController: RequestHandler = async (req, res) => {
             case "/Lotus/Types/Items/MiscItems/FormaStance":
                 for (const item of inventory[payload.ItemCategory as TEquipmentKey] as IEquipmentDatabase[]) {
                     if (item._id.toString() == payload.ItemId.$oid) {
+                        if (!config.NoResetPolarize) {
                         item.XP = 0;
+                        }
                         setSlotPolarity(item, operation.PolarizeSlot, operation.PolarizeValue);
                         item.Polarized ??= 0;
                         item.Polarized += 1;

--- a/src/controllers/api/upgradesController.ts
+++ b/src/controllers/api/upgradesController.ts
@@ -66,7 +66,7 @@ export const upgradesController: RequestHandler = async (req, res) => {
                 for (const item of inventory[payload.ItemCategory as TEquipmentKey] as IEquipmentDatabase[]) {
                     if (item._id.toString() == payload.ItemId.$oid) {
                         if (!config.NoResetPolarize) {
-                        item.XP = 0;
+                            item.XP = 0;
                         }
                         setSlotPolarity(item, operation.PolarizeSlot, operation.PolarizeValue);
                         item.Polarized ??= 0;

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -37,6 +37,7 @@ interface IConfig {
     unlockAllShipDecorations?: boolean;
     unlockAllFlavourItems?: boolean;
     unlockAllSkins?: boolean;
+    NoResetPolarize?: boolean;
     spoofMasteryRank?: number;
 }
 


### PR DESCRIPTION
The game will reset your XP in any case, but if you relogin or go to any location you will have an instant lvl 30.
If this is possible bypass let me know.