### PR TITLE
improve: use all supported nodejs versions in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,16 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                version: [18, 20, 22]
         steps:
             - name: Checkout
               uses: actions/checkout@v4.1.2
             - name: Setup Node.js environment
               uses: actions/setup-node@v4.0.2
               with:
-                  node-version: "20.x"
+                  node-version: ${{ matrix.version }}
             - run: npm ci
             - run: cp config.json.example config.json
             - run: echo '{"version":"","buildLabel":"","matchmakingBuildId":""}' > static/data/buildConfig.json


### PR DESCRIPTION
Just to ensure we don't hit any edge cases.