### PR TITLE
chore: update warframe-riven-info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "express": "^5.0.0-beta.3",
         "mongoose": "^8.4.5",
         "warframe-public-export-plus": "^0.5.2",
-        "warframe-riven-info": "^0.1.1",
+        "warframe-riven-info": "^0.1.2",
         "winston": "^3.13.0",
         "winston-daily-rotate-file": "^5.0.0"
       },
@@ -3783,9 +3783,9 @@
       "integrity": "sha512-mv7abHis5ytlevnx9lSLwnqnv5/3t322/OKkR99Hrw+w7Qm+Ps6agZcTqNaIy6zrM1vsvWY1NnbxVe2+JIW6/Q=="
     },
     "node_modules/warframe-riven-info": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/warframe-riven-info/-/warframe-riven-info-0.1.1.tgz",
-      "integrity": "sha512-Flh4aObS+b+YroemTyrFflM0N6AmjqPhVXi52M7JDr9BLSVPUQJMaccQpEdgrdbVfgkPzrdHvVgAjXEhA7CslQ=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/warframe-riven-info/-/warframe-riven-info-0.1.2.tgz",
+      "integrity": "sha512-j09BbfWGyCEKv19jP8c0/Eb0gupJsyLNGaHgCIg3wYkTx5dlr8jSPfTpB1rkMOUiURpWKAOrfnPGrgFPbfNtWw=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^5.0.0-beta.3",
     "mongoose": "^8.4.5",
     "warframe-public-export-plus": "^0.5.2",
-    "warframe-riven-info": "^0.1.1",
+    "warframe-riven-info": "^0.1.2",
     "winston": "^3.13.0",
     "winston-daily-rotate-file": "^5.0.0"
   },


### PR DESCRIPTION
The latest version of RivenParser.js fixes some issues like erroring on rivens without a curses array.