### PR TITLE
improve: make infiniteResources stick out less

### DIFF
--- a/src/controllers/api/getCreditsController.ts
+++ b/src/controllers/api/getCreditsController.ts
@@ -17,8 +17,8 @@ export const getCreditsController: RequestHandler = async (req, res) => {
         res.json({
             RegularCredits: 999999999,
             TradesRemaining: 999999999,
-            PremiumCreditsFree: 999999999,
-            PremiumCredits: 999999999
+            PremiumCreditsFree: 0,
+            PremiumCredits: 10000
         });
         return;
     }

--- a/src/controllers/api/inventoryController.ts
+++ b/src/controllers/api/inventoryController.ts
@@ -37,8 +37,8 @@ const inventoryController: RequestHandler = async (request, response) => {
     if (config.infiniteResources) {
         inventoryResponse.RegularCredits = 999999999;
         inventoryResponse.TradesRemaining = 999999999;
-        inventoryResponse.PremiumCreditsFree = 999999999;
-        inventoryResponse.PremiumCredits = 999999999;
+        inventoryResponse.PremiumCreditsFree = 0;
+        inventoryResponse.PremiumCredits = 10000;
     }
 
     if (config.skipAllDialogue) {


### PR DESCRIPTION
A great many screenshots taken with OpenWF have the 1,000,000,000 in the top-right which is often not the main point of the screenshot, but still draws needless attention to itself.