### PR TITLE
feat: implement syndicateStandingBonus endpoint

### DIFF
--- a/src/controllers/api/syndicateStandingBonusController.ts
+++ b/src/controllers/api/syndicateStandingBonusController.ts
@@ -1,0 +1,61 @@
+import { RequestHandler } from "express";
+import { getAccountIdForRequest } from "@/src/services/loginService";
+import { addMiscItems, getInventory } from "@/src/services/inventoryService";
+import { IMiscItem } from "@/src/types/inventoryTypes/inventoryTypes";
+import { IOid } from "@/src/types/commonTypes";
+import { ExportSyndicates } from "warframe-public-export-plus";
+
+export const syndicateStandingBonusController: RequestHandler = async (req, res) => {
+    const accountId = await getAccountIdForRequest(req);
+    const request = JSON.parse(String(req.body)) as ISyndicateStandingBonusRequest;
+
+    let gainedStanding = 0;
+    request.Operation.Items.forEach(item => {
+        const medallion = (ExportSyndicates[request.Operation.AffiliationTag].medallions ?? []).find(
+            medallion => medallion.itemType == item.ItemType
+        );
+        if (medallion) {
+            gainedStanding += medallion.standing * item.ItemCount;
+        }
+
+        item.ItemCount *= -1;
+    });
+
+    const inventory = await getInventory(accountId);
+    addMiscItems(inventory, request.Operation.Items);
+
+    const syndicate = inventory.Affiliations.find(x => x.Tag == request.Operation.AffiliationTag);
+    if (syndicate !== undefined) {
+        syndicate.Standing += gainedStanding;
+    } else {
+        inventory.Affiliations.push({
+            Tag: request.Operation.AffiliationTag,
+            Standing: gainedStanding
+        });
+    }
+
+    // TODO: Subtract from daily limit bin; maybe also a cheat to skip that.
+
+    await inventory.save();
+
+    res.json({
+        InventoryChanges: {
+            MiscItems: request.Operation.Items
+        },
+        AffiliationMods: [
+            {
+                Tag: request.Operation.AffiliationTag,
+                Standing: gainedStanding
+            }
+        ]
+    });
+};
+
+interface ISyndicateStandingBonusRequest {
+    Operation: {
+        AffiliationTag: string;
+        AlternateBonusReward: ""; // ???
+        Items: IMiscItem[];
+    };
+    ModularWeaponId: IOid; // Seems to just be "000000000000000000000000", also note there's a "Category" query field
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -61,6 +61,7 @@ import { startRecipeController } from "@/src/controllers/api/startRecipeControll
 import { stepSequencersController } from "@/src/controllers/api/stepSequencersController";
 import { surveysController } from "@/src/controllers/api/surveysController";
 import { syndicateSacrificeController } from "../controllers/api/syndicateSacrificeController";
+import { syndicateStandingBonusController } from "../controllers/api/syndicateStandingBonusController";
 import { tauntHistoryController } from "@/src/controllers/api/tauntHistoryController";
 import { trainingResultController } from "@/src/controllers/api/trainingResultController";
 import { updateChallengeProgressController } from "@/src/controllers/api/updateChallengeProgressController";
@@ -137,6 +138,7 @@ apiRouter.post("/startDojoRecipe.php", startDojoRecipeController);
 apiRouter.post("/startRecipe.php", startRecipeController);
 apiRouter.post("/stepSequencers.php", stepSequencersController);
 apiRouter.post("/syndicateSacrifice.php", syndicateSacrificeController);
+apiRouter.post("/syndicateStandingBonus.php", syndicateStandingBonusController);
 apiRouter.post("/tauntHistory.php", tauntHistoryController);
 apiRouter.post("/trainingResult.php", trainingResultController);
 apiRouter.post("/updateChallengeProgress.php", updateChallengeProgressController);


### PR DESCRIPTION
Closes #535. Currently doesn't consider standing limits so you can end up with extra standing.