### PR TITLE
feat: respect client-supplied version information

### DIFF
--- a/src/controllers/api/loginController.ts
+++ b/src/controllers/api/loginController.ts
@@ -20,6 +20,11 @@ const loginController: RequestHandler = async (request, response) => {
     const account = await Account.findOne({ email: loginRequest.email }); //{ _id: 0, __v: 0 }
     const nonce = Math.round(Math.random() * Number.MAX_SAFE_INTEGER);
 
+    const buildLabel: string =
+        typeof request.query.buildLabel == "string"
+            ? request.query.buildLabel.split(" ").join("+")
+            : buildConfig.buildLabel;
+
     if (!account && config.autoCreateAccount && loginRequest.ClientType != "webui") {
         try {
             const newAccount = await createAccount({
@@ -45,7 +50,7 @@ const loginController: RequestHandler = async (request, response) => {
                 DTLS: DTLS,
                 IRC: config.myIrcAddresses ?? [config.myAddress],
                 HUB: HUB,
-                BuildLabel: buildConfig.buildLabel,
+                BuildLabel: buildLabel,
                 MatchmakingBuildId: buildConfig.matchmakingBuildId
             };
 
@@ -81,7 +86,7 @@ const loginController: RequestHandler = async (request, response) => {
         DTLS: DTLS,
         IRC: config.myIrcAddresses ?? [config.myAddress],
         HUB: HUB,
-        BuildLabel: buildConfig.buildLabel,
+        BuildLabel: buildLabel,
         MatchmakingBuildId: buildConfig.matchmakingBuildId
     };
 

--- a/src/controllers/dynamic/worldStateController.ts
+++ b/src/controllers/dynamic/worldStateController.ts
@@ -2,10 +2,13 @@ import { RequestHandler } from "express";
 import worldState from "@/static/fixed_responses/worldState.json";
 import buildConfig from "@/static/data/buildConfig.json";
 
-const worldStateController: RequestHandler = (_req, res) => {
+const worldStateController: RequestHandler = (req, res) => {
+    const buildLabel: string =
+        typeof req.query.buildLabel == "string" ? req.query.buildLabel.split(" ").join("+") : buildConfig.buildLabel;
+
     res.json({
         ...worldState,
-        BuildLabel: buildConfig.buildLabel,
+        BuildLabel: buildLabel,
         Time: Math.round(Date.now() / 1000)
     });
 };

--- a/src/routes/cache.ts
+++ b/src/routes/cache.ts
@@ -4,8 +4,12 @@ import fs from "fs/promises";
 
 const cacheRouter = express.Router();
 
-cacheRouter.get(/^\/origin\/[a-zA-Z0-9]+\/[0-9]+\/H\.Cache\.bin.*$/, (_req, res) => {
-    res.sendFile(`static/data/H.Cache_${buildConfig.version}.bin`, { root: "./" });
+cacheRouter.get(/^\/origin\/[a-zA-Z0-9]+\/[0-9]+\/H\.Cache\.bin.*$/, (req, res) => {
+    if (typeof req.query.version == "string" && req.query.version.match(/^\d\d\d\d\.\d\d\.\d\d\.\d\d\.\d\d$/)) {
+        res.sendFile(`static/data/H.Cache_${req.query.version}.bin`, { root: "./" });
+    } else {
+        res.sendFile(`static/data/H.Cache_${buildConfig.version}.bin`, { root: "./" });
+    }
 });
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises


### PR DESCRIPTION
Newer versions of the DLL (>=0.6.0) can determine the client version and will tell the server via query parameters on these relevant requests. The server of course still needs to have a copy of the relevant H.Cache.bin file.