### PR TITLE
Fix environment to config.json parser

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ for config in $(env | grep "APP_")
 do
   var=$(echo "${config}" | tr '[:upper:]' '[:lower:]' | sed 's/app_//g' | sed -E 's/_([a-z])/\U\1/g' | sed 's/=.*//g')
   val=$(echo "${config}" | sed 's/.*=//g')
-  jq --arg variable "$var" --arg value "$val" '.[$variable] += $value' config.json > config.tmp
+  jq --arg variable "$var" --arg value "$val" '.[$variable] += try [$value|fromjson][] catch $value' config.json > config.tmp
   mv config.tmp config.json
 done
 


### PR DESCRIPTION
The current `docker-entrypoint.sh` will write all numeric and boolean environment variables to `config.json` as strings, which will make most configurations invalid.
This Pull Request attempts to read the parameter in JSON format first. If it cannot be parsed, it is considered a string.

before
```json
{
  "logger": {
    "files": true,
    "level": "trace",
    "__valid_levels": "fatal, error, warn, info, http, debug, trace"
  },
  "universalPolarityEverywhere": "true",
  "unlockAllShipFeatures": "false",
  "httpsPort": "443",
  "spoofMasteryRank": "-1",
  "unlockAllShipDecorations": "false",
  "skipStoryModeChoice": "false",
  "autoCreateAccount": "true",
  "httpPort": "80",
  "skipAllDialogue": "false",
  "unlockAllSkins": "false",
  "completeAllQuests": "false",
  "unlockAllFlavourItems": "false",
  "mongodbUrl": "mongodb://mongodb:27017/",
  "unlockAllQuests": "false",
  "unlockAllScans": "false",
  "unlockAllMissions": "false",
  "skipTutorial": "false",
  "myAddress": "localhost",
  "infiniteResources": "false"
}
```

after
```json
{
  "logger": {
    "files": true,
    "level": "trace",
    "__valid_levels": "fatal, error, warn, info, http, debug, trace"
  },
  "universalPolarityEverywhere": true,
  "unlockAllShipFeatures": false,
  "httpsPort": 443,
  "spoofMasteryRank": -1,
  "unlockAllShipDecorations": false,
  "skipStoryModeChoice": false,
  "autoCreateAccount": true,
  "httpPort": 80,
  "skipAllDialogue": false,
  "unlockAllSkins": false,
  "completeAllQuests": false,
  "unlockAllFlavourItems": false,
  "mongodbUrl": "mongodb://mongodb:27017/",
  "unlockAllQuests": false,
  "unlockAllScans": false,
  "unlockAllMissions": false,
  "skipTutorial": false,
  "myAddress": "localhost",
  "infiniteResources": false
}
```