### PR TITLE
fix: inconsistent handling of purchase request

### DIFF
--- a/src/controllers/api/purchaseController.ts
+++ b/src/controllers/api/purchaseController.ts
@@ -1,11 +1,11 @@
 import { RequestHandler } from "express";
 import { getAccountIdForRequest } from "@/src/services/loginService";
-import { toPurchaseRequest } from "@/src/helpers/purchaseHelpers";
+import { IPurchaseRequest } from "@/src/types/purchaseTypes";
 import { handlePurchase } from "@/src/services/purchaseService";
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 export const purchaseController: RequestHandler = async (req, res) => {
-    const purchaseRequest = toPurchaseRequest(JSON.parse(String(req.body)));
+    const purchaseRequest = JSON.parse(String(req.body)) as IPurchaseRequest;
     const accountId = await getAccountIdForRequest(req);
     const response = await handlePurchase(purchaseRequest, accountId);
     res.json(response);

--- a/src/helpers/purchaseHelpers.ts
+++ b/src/helpers/purchaseHelpers.ts
@@ -1,43 +1,5 @@
-import { parseBoolean, parseNumber, parseString } from "@/src/helpers/general";
 import { slotPurchaseNameToSlotName } from "@/src/services/purchaseService";
-import { IPurchaseRequest, SlotPurchaseName } from "@/src/types/purchaseTypes";
-
-export const toPurchaseRequest = (purchaseRequest: unknown): IPurchaseRequest => {
-    if (!purchaseRequest || typeof purchaseRequest !== "object") {
-        throw new Error("incorrect or missing purchase request data");
-    }
-
-    if (
-        "PurchaseParams" in purchaseRequest &&
-        "buildLabel" in purchaseRequest &&
-        purchaseRequest.PurchaseParams &&
-        typeof purchaseRequest.PurchaseParams === "object" &&
-        "Source" in purchaseRequest.PurchaseParams &&
-        "StoreItem" in purchaseRequest.PurchaseParams &&
-        "StorePage" in purchaseRequest.PurchaseParams &&
-        "SearchTerm" in purchaseRequest.PurchaseParams &&
-        "CurrentLocation" in purchaseRequest.PurchaseParams &&
-        "Quantity" in purchaseRequest.PurchaseParams &&
-        "UsePremium" in purchaseRequest.PurchaseParams &&
-        "ExpectedPrice" in purchaseRequest.PurchaseParams
-    ) {
-        return {
-            PurchaseParams: {
-                Source: parseNumber(purchaseRequest.PurchaseParams.Source),
-                StoreItem: parseString(purchaseRequest.PurchaseParams.StoreItem),
-                StorePage: parseString(purchaseRequest.PurchaseParams.StorePage),
-                SearchTerm: parseString(purchaseRequest.PurchaseParams.SearchTerm),
-                CurrentLocation: parseString(purchaseRequest.PurchaseParams.CurrentLocation),
-                Quantity: parseNumber(purchaseRequest.PurchaseParams.Quantity),
-                UsePremium: parseBoolean(purchaseRequest.PurchaseParams.UsePremium),
-                ExpectedPrice: parseNumber(purchaseRequest.PurchaseParams.ExpectedPrice)
-            },
-            buildLabel: parseString(purchaseRequest.buildLabel)
-        };
-    }
-
-    throw new Error("invalid purchaseRequest");
-};
+import { SlotPurchaseName } from "@/src/types/purchaseTypes";
 
 export const isSlotPurchaseName = (slotPurchaseName: string): slotPurchaseName is SlotPurchaseName => {
     return slotPurchaseName in slotPurchaseNameToSlotName;


### PR DESCRIPTION
We typically don't 'validate' requests. In this case, this also results in some fields of the request being lost as they are not handled in the validate/parse function.