### PR TITLE
fix: consistenly use static/data for 'npm run build'

### DIFF
--- a/src/controllers/api/loginController.ts
+++ b/src/controllers/api/loginController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from "express";
 
 import { config } from "@/src/services/configService";
-import buildConfig from "@/static/data/buildConfig.json";
+import { buildConfig } from "@/src/services/buildConfigService";
 
 import { Account } from "@/src/models/loginModel";
 import { createAccount, isCorrectPassword, isNameTaken } from "@/src/services/loginService";

--- a/src/controllers/dynamic/worldStateController.ts
+++ b/src/controllers/dynamic/worldStateController.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from "express";
 import staticWorldState from "@/static/fixed_responses/worldState.json";
-import buildConfig from "@/static/data/buildConfig.json";
+import { buildConfig } from "@/src/services/buildConfigService";
 import { IMongoDate, IOid } from "@/src/types/commonTypes";
 
 export const worldStateController: RequestHandler = (req, res) => {

--- a/src/routes/cache.ts
+++ b/src/routes/cache.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import buildConfig from "@/static/data/buildConfig.json";
+import { buildConfig } from "@/src/services/buildConfigService";
 import fs from "fs/promises";
 
 const cacheRouter = express.Router();

--- a/src/services/buildConfigService.ts
+++ b/src/services/buildConfigService.ts
@@ -1,0 +1,13 @@
+import path from "path";
+import fs from "fs";
+
+const rootDir = path.join(__dirname, "../..");
+const repoDir = path.basename(rootDir) == "build" ? path.join(rootDir, "..") : rootDir;
+const buildConfigPath = path.join(repoDir, "static/data/buildConfig.json");
+export const buildConfig = JSON.parse(fs.readFileSync(buildConfigPath, "utf-8")) as IBuildConfig;
+
+interface IBuildConfig {
+    version: string;
+    buildLabel: string;
+    matchmakingBuildId: string;
+}


### PR DESCRIPTION
Previously, buildConfig.json was loaded from build/static/data while cache files were loaded from static/data. Now all files are loaded from static/data and there is no build/static/data folder anymore.