### PR TITLE
fix: check if a crewmate exists before attempting to create an OID for it

### DIFF
--- a/src/models/inventoryModels/inventoryModel.ts
+++ b/src/models/inventoryModels/inventoryModel.ts
@@ -682,11 +682,11 @@ crewShipMembersSchema.set("toJSON", {
     virtuals: true,
     transform(_doc, ret) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ret.SLOT_A = { ItemId: toOid(ret.SLOT_A) };
+        ret.SLOT_A ? { ItemId: toOid(ret.SLOT_A) } : null;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ret.SLOT_B = { ItemId: toOid(ret.SLOT_B) };
+        ret.SLOT_B ? { ItemId: toOid(ret.SLOT_B) } : null;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ret.SLOT_C = { ItemId: toOid(ret.SLOT_C) };
+        ret.SLOT_C ? { ItemId: toOid(ret.SLOT_C) } : null;
     }
 });
 


### PR DESCRIPTION
inventoryModels.toOid() would throw a bunch of `Cannot read properties of undefined (reading 'toString') while processing /api/inventory.php request` errors preventing users from logging in essentially breaking their account if they have a railjack but no crewmates

edit: typo `inventoryModels.toOid()` not `inventoryHelpers.toOid()`