### PR TITLE
fix: make crew member slots optional

### DIFF
--- a/src/models/inventoryModels/inventoryModel.ts
+++ b/src/models/inventoryModels/inventoryModel.ts
@@ -42,7 +42,7 @@ import {
     ICrewShipPortGuns,
     ICrewShipCustomization,
     ICrewShipWeapon,
-    ICrewShipMembers,
+    ICrewShipMembersClient,
     ICrewShip,
     ICrewShipPilotWeapon,
     IShipExterior,
@@ -683,7 +683,7 @@ crewShipMembersSchema.set("toJSON", {
     virtuals: true,
     transform(_doc, obj) {
         const db = obj as ICrewShipMembersDatabase;
-        const client = obj as ICrewShipMembers;
+        const client = obj as ICrewShipMembersClient;
         client.SLOT_A = db.SLOT_A ? { ItemId: toOid(db.SLOT_A) } : undefined;
         client.SLOT_B = db.SLOT_B ? { ItemId: toOid(db.SLOT_B) } : undefined;
         client.SLOT_C = db.SLOT_C ? { ItemId: toOid(db.SLOT_C) } : undefined;

--- a/src/models/inventoryModels/inventoryModel.ts
+++ b/src/models/inventoryModels/inventoryModel.ts
@@ -46,7 +46,8 @@ import {
     ICrewShip,
     ICrewShipPilotWeapon,
     IShipExterior,
-    IHelminthFoodRecord
+    IHelminthFoodRecord,
+    ICrewShipMembersDatabase
 } from "../../types/inventoryTypes/inventoryTypes";
 import { IOid } from "../../types/commonTypes";
 import {
@@ -670,23 +671,22 @@ const crewShipCustomizationSchema = new Schema<ICrewShipCustomization>(
     { _id: false }
 );
 
-const crewShipMembersSchema = new Schema<ICrewShipMembers>(
+const crewShipMembersSchema = new Schema<ICrewShipMembersDatabase>(
     {
-        SLOT_A: Schema.Types.ObjectId,
-        SLOT_B: Schema.Types.ObjectId,
-        SLOT_C: Schema.Types.ObjectId
+        SLOT_A: { type: Schema.Types.ObjectId, required: false },
+        SLOT_B: { type: Schema.Types.ObjectId, required: false },
+        SLOT_C: { type: Schema.Types.ObjectId, required: false }
     },
     { _id: false }
 );
 crewShipMembersSchema.set("toJSON", {
     virtuals: true,
-    transform(_doc, ret) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ret.SLOT_A = { ItemId: toOid(ret.SLOT_A) };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ret.SLOT_B = { ItemId: toOid(ret.SLOT_B) };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ret.SLOT_C = { ItemId: toOid(ret.SLOT_C) };
+    transform(_doc, obj) {
+        const db = obj as ICrewShipMembersDatabase;
+        const client = obj as ICrewShipMembers;
+        client.SLOT_A = db.SLOT_A ? { ItemId: toOid(db.SLOT_A) } : undefined;
+        client.SLOT_B = db.SLOT_B ? { ItemId: toOid(db.SLOT_B) } : undefined;
+        client.SLOT_C = db.SLOT_C ? { ItemId: toOid(db.SLOT_C) } : undefined;
     }
 });
 

--- a/src/types/inventoryTypes/inventoryTypes.ts
+++ b/src/types/inventoryTypes/inventoryTypes.ts
@@ -432,13 +432,19 @@ export interface ICrewShip {
 }
 
 export interface ICrewShipMembers {
-    SLOT_A: ISlot;
-    SLOT_B: ISlot;
-    SLOT_C: ISlot;
+    SLOT_A?: ISlot;
+    SLOT_B?: ISlot;
+    SLOT_C?: ISlot;
 }
 
 export interface ISlot {
     ItemId: IOid;
+}
+
+export interface ICrewShipMembersDatabase {
+    SLOT_A?: Types.ObjectId;
+    SLOT_B?: Types.ObjectId;
+    SLOT_C?: Types.ObjectId;
 }
 
 export interface ICrewShipCustomization {

--- a/src/types/inventoryTypes/inventoryTypes.ts
+++ b/src/types/inventoryTypes/inventoryTypes.ts
@@ -426,12 +426,12 @@ export interface ICrewShip {
     Customization?: ICrewShipCustomization;
     ItemName: string;
     RailjackImage?: IFlavourItem;
-    CrewMembers?: ICrewShipMembers;
+    CrewMembers?: ICrewShipMembersClient;
     ItemId: IOid;
     _id: Types.ObjectId;
 }
 
-export interface ICrewShipMembers {
+export interface ICrewShipMembersClient {
     SLOT_A?: ISlot;
     SLOT_B?: ISlot;
     SLOT_C?: ISlot;


### PR DESCRIPTION
it is possible to e.g. only have 2/3 crew members active, then one of the slots is simply absent.