### PR TITLE
feat(webui): add "max rank all warframes" & "max rank all weapons"

### DIFF
--- a/static/webui/index.html
+++ b/static/webui/index.html
@@ -110,9 +110,11 @@
                         </div>
                         <div class="card mb-3">
                             <h5 class="card-header">Bulk Actions</h5>
-                            <div class="card-body">
-                                <button class="btn btn-primary" onclick="addMissingWarframes();">Add Missing Warframes</button>
-                                <button class="btn btn-primary" onclick="addMissingWeapons();">Add Missing Weapons</button>
+                            <div class="card-body d-flex flex-wrap gap-2">
+                                <button class="btn btn-primary flex-grow-1" onclick="addMissingWarframes();">Add Missing Warframes</button>
+                                <button class="btn btn-primary flex-grow-1" onclick="addMissingWeapons();">Add Missing Weapons</button>
+                                <button class="btn btn-primary flex-grow-1" onclick="maxRankAllWarframes()">Max Rank All Warframes</button>
+                                <button class="btn btn-primary flex-grow-1" onclick="maxRankAllWeapons()">Max Rank All Weapons</button>
                             </div>
                         </div>
                     </div>

--- a/static/webui/index.html
+++ b/static/webui/index.html
@@ -96,9 +96,9 @@
                 </div>
                 <div class="row g-3">
                     <div class="col-lg-6">
-                        <div class="card mb-3">
+                        <div class="card mb-3" style="height: 480px;">
                             <h5 class="card-header">Warframes</h5>
-                            <div class="card-body">
+                            <div class="card-body overflow-auto">
                                 <form class="input-group mb-3" onsubmit="doAcquireWarframe();return false;">
                                     <input class="form-control" id="warframe-to-acquire" list="datalist-warframes" />
                                     <button class="btn btn-primary" type="submit">Add</button>
@@ -119,9 +119,9 @@
                         </div>
                     </div>
                     <div class="col-lg-6">
-                        <div class="card mb-3">
+                        <div class="card mb-3" style="height: 480px;">
                             <h5 class="card-header">Weapons</h5>
-                            <div class="card-body">
+                            <div class="card-body overflow-auto">
                                 <form class="input-group mb-3" onsubmit="doAcquireWeapon();return false;">
                                     <input class="form-control" id="weapon-to-acquire" list="datalist-weapons" />
                                     <button class="btn btn-primary" type="submit">Add</button>

--- a/static/webui/index.html
+++ b/static/webui/index.html
@@ -108,15 +108,6 @@
                                 </table>
                             </div>
                         </div>
-                        <div class="card mb-3">
-                            <h5 class="card-header">Bulk Actions</h5>
-                            <div class="card-body d-flex flex-wrap gap-2">
-                                <button class="btn btn-primary flex-grow-1" onclick="addMissingWarframes();">Add Missing Warframes</button>
-                                <button class="btn btn-primary flex-grow-1" onclick="addMissingWeapons();">Add Missing Weapons</button>
-                                <button class="btn btn-primary flex-grow-1" onclick="maxRankAllWarframes()">Max Rank All Warframes</button>
-                                <button class="btn btn-primary flex-grow-1" onclick="maxRankAllWeapons()">Max Rank All Weapons</button>
-                            </div>
-                        </div>
                     </div>
                     <div class="col-lg-6">
                         <div class="card mb-3" style="height: 480px;">
@@ -131,6 +122,15 @@
                                 </table>
                             </div>
                         </div>
+                    </div>
+                </div>
+                <div class="card mb-3">
+                    <h5 class="card-header">Bulk Actions</h5>
+                    <div class="card-body d-flex flex-wrap gap-2">
+                        <button class="btn btn-primary" onclick="addMissingWarframes();">Add Missing Warframes</button>
+                        <button class="btn btn-primary" onclick="addMissingWeapons();">Add Missing Weapons</button>
+                        <button class="btn btn-success" onclick="maxRankAllWarframes()">Max Rank All Warframes</button>
+                        <button class="btn btn-success" onclick="maxRankAllWeapons()">Max Rank All Weapons</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Adds 2 new buttons in the bulk actions container

1. to make every owned warframe max rank
2. to make every owned weapon max rank

also made the lists have a max width so the page doesnt need to be scrolled down all the way to see the buttons