### PR TITLE
fix: syndicate sacrifice doesn't persist new title

### DIFF
--- a/src/controllers/api/syndicateSacrificeController.ts
+++ b/src/controllers/api/syndicateSacrificeController.ts
@@ -47,7 +47,8 @@ export const syndicateSacrificeController: RequestHandler = async (request, resp
         res.InventoryChanges.MiscItems = miscItemChanges;
     }
 
-    if (syndicate?.Title !== undefined) syndicate.Title += 1;
+    syndicate.Title ??= 0;
+    syndicate.Title += 1;
 
     await inventory.save();
 


### PR DESCRIPTION
This actually fixes #392 as the missionInventoryUpdate logic regarding this seems to be correct.