### PR TITLE
fix: identify correct offer for when teshin has 2 kuva offers up

### DIFF
--- a/src/services/purchaseService.ts
+++ b/src/services/purchaseService.ts
@@ -49,14 +49,15 @@ export const handlePurchase = async (
 
     if (purchaseRequest.PurchaseParams.Source == 7) {
         const manifest = getVendorManifestByOid(purchaseRequest.PurchaseParams.SourceId!);
-        if (manifest) {
-            const offer = manifest.VendorInfo.ItemManifest.find(
-                x => x.StoreItem == purchaseRequest.PurchaseParams.StoreItem
-            );
-            if (offer) {
-                purchaseRequest.PurchaseParams.Quantity *= offer.QuantityMultiplier;
-            }
+        if (!manifest) {
+            throw new Error(`unknown vendor id: ${purchaseRequest.PurchaseParams.SourceId!}`);
         }
+        const ItemId = (JSON.parse(purchaseRequest.PurchaseParams.ExtraPurchaseInfoJson!) as { ItemId: string }).ItemId;
+        const offer = manifest.VendorInfo.ItemManifest.find(x => x.Id.$oid == ItemId);
+        if (!offer) {
+            throw new Error(`unknown vendor offer: ${ItemId}`);
+        }
+        purchaseRequest.PurchaseParams.Quantity *= offer.QuantityMultiplier;
     }
 
     const purchaseResponse = await handleStoreItemAcquisition(

--- a/src/types/purchaseTypes.ts
+++ b/src/types/purchaseTypes.ts
@@ -17,6 +17,8 @@ export interface IPurchaseParams {
     ExpectedPrice: number;
     SyndicateTag?: string; // for Source 2
     UseFreeFavor?: boolean; // for Source 2
+    ExtraPurchaseInfoJson?: string; // for Source 7
+    IsWeekly?: boolean; // for Source 7
 }
 
 export interface ICurrencyChanges {


### PR DESCRIPTION
Closes #738, as otherwise the rotation is actually already handled by the client. We just need to use the ItemId it gives us.