### PR TITLE
fix: automatically prune references that no longer exist remotely

### DIFF
--- a/UPDATE AND START SERVER.bat
+++ b/UPDATE AND START SERVER.bat
@@ -1,6 +1,7 @@
 @echo off
 
 echo Updating SpaceNinjaServer...
+git config remote.origin.prune true
 git pull
 
 if exist static\data\0\ (


### PR DESCRIPTION
It's possible one might acquire a lot of dead references from continually updating the server, so this will automatically prune them when synchronising with the git remote.