### PR TITLE
fix: aborting Mission and completeAllQuests config

### DIFF
--- a/src/controllers/api/inventoryController.ts
+++ b/src/controllers/api/inventoryController.ts
@@ -107,6 +107,7 @@ export const inventoryController: RequestHandler = async (request, response) => 
         }
     }
     if (config.completeAllQuests) {
+        console.log("Completing all quests");
         for (const quest of inventoryResponse.QuestKeys) {
             quest.unlock = true;
             quest.Completed = true;
@@ -127,6 +128,7 @@ export const inventoryController: RequestHandler = async (request, response) => 
         }
 
         inventoryResponse.ArchwingEnabled = true;
+        inventoryResponse.ActiveQuest = ""; //TODO: might need to reconsider this if this does not work long term.
 
         // Skip "Watch The Maker"
         addString(inventoryResponse.NodeIntrosCompleted, "/Lotus/Levels/Cinematics/NewWarIntro/NewWarStageTwo.level");

--- a/src/controllers/api/inventoryController.ts
+++ b/src/controllers/api/inventoryController.ts
@@ -107,7 +107,6 @@ export const inventoryController: RequestHandler = async (request, response) => 
         }
     }
     if (config.completeAllQuests) {
-        console.log("Completing all quests");
         for (const quest of inventoryResponse.QuestKeys) {
             quest.unlock = true;
             quest.Completed = true;

--- a/src/controllers/api/missionInventoryUpdateController.ts
+++ b/src/controllers/api/missionInventoryUpdateController.ts
@@ -58,6 +58,7 @@ export const missionInventoryUpdateController: RequestHandler = async (req, res)
         console.log(`Mission failed: ${missionReport.RewardInfo?.node}`);
         //todo: return expected response for failed mission
         res.json([]);
+        return;
         //duvirisadjob does not provide missionStatus
     }
 

--- a/src/types/inventoryTypes/inventoryTypes.ts
+++ b/src/types/inventoryTypes/inventoryTypes.ts
@@ -43,7 +43,6 @@ export interface IInventoryDatabase
     GuildId?: Types.ObjectId; // GuildId changed from ?IOid to ?Types.ObjectId
     PendingRecipes: IPendingRecipe[];
     QuestKeys: IQuestKeyDatabase[];
-    ActiveQuest: string;
     BlessingCooldown: Date;
     Ships: Types.ObjectId[];
     WeaponSkins: IWeaponSkinDatabase[];
@@ -207,6 +206,7 @@ export interface IInventoryClient extends IDailyAffiliations {
     ReceivedStartingGear: boolean;
     Ships: IShipInventory[];
     QuestKeys: IQuestKeyClient[];
+    ActiveQuest: string;
     FlavourItems: IFlavourItem[];
     Scoops: IEquipmentDatabase[];
     LoadOutPresets: ILoadOutPresets;


### PR DESCRIPTION
temp fix for completeAllQuests: you won't be able to start a new quest with the config option enabled.
This will be changed in the future by making the feature an account based web-ui option.

closes #856 #855 